### PR TITLE
Fix stray script text in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,10 +782,6 @@
     gtag('js', new Date());
     gtag('config', 'G-CJWXG1W4EV');
   </script>
-  <!-- jQuery, Popper, Bootstrap JS (order matters) -->\n
-  <script src=\"https://code.jquery.com/jquery-3.6.0.min.js\"></script>\n
-  <script src=\"https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js\"></script>\n
-  <script src=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js\"></script>\n
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- remove spurious text containing escaped newlines at bottom of index.html

## Testing
- `npm test` *(fails: Could not find package.json)*